### PR TITLE
Disable and Re-enable Quick Reply Buttons

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,11 +100,37 @@ class QrBarToggle {
             //qrBar.style.borderTopColor = 'var(--SmartThemeBodyColor)';
             toggleButton.className = 'fa-solid fa-chevron-down interactable';
             toggleButton.title = 'Collapse QR Bar';
+
+            // Enable buttons within QR bar
+            const buttonsInQrBar = qrBar.querySelectorAll('.qr--button, [id^="qr_"], .inline-drawer-toggle');
+            buttonsInQrBar.forEach(button => {
+                button.style.pointerEvents = 'auto';
+                button.style.opacity = '1';
+                if (button.tagName === 'BUTTON' || (button.tagName === 'INPUT' && button.type === 'button')) {
+                    button.disabled = false;
+                }
+                if (button.hasAttribute('aria-disabled')) {
+                    button.setAttribute('aria-disabled', 'false');
+                }
+            });
         } else {
             qrBar.className = `${baseClass} sqrbt-toggle_button-collapsed`;
             //qrBar.style.borderTopColor = 'var(--SmartThemeQuoteColor)';
             toggleButton.className = 'fa-solid fa-chevron-up interactable';
             toggleButton.title = 'Expand QR Bar';
+
+            // Disable buttons within QR bar
+            const buttonsInQrBar = qrBar.querySelectorAll('.qr--button, [id^="qr_"], .inline-drawer-toggle');
+            buttonsInQrBar.forEach(button => {
+                button.style.pointerEvents = 'none';
+                button.style.opacity = '0.5'; // Visually indicate disabled state
+                if (button.tagName === 'BUTTON' || (button.tagName === 'INPUT' && button.type === 'button')) {
+                    button.disabled = true;
+                }
+                if (button.hasAttribute('aria-disabled')) {
+                    button.setAttribute('aria-disabled', 'true');
+                }
+            });
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -123,7 +123,6 @@ class QrBarToggle {
             const buttonsInQrBar = qrBar.querySelectorAll('.qr--button, [id^="qr_"], .inline-drawer-toggle');
             buttonsInQrBar.forEach(button => {
                 button.style.pointerEvents = 'none';
-                button.style.opacity = '0.5'; // Visually indicate disabled state
                 if (button.tagName === 'BUTTON' || (button.tagName === 'INPUT' && button.type === 'button')) {
                     button.disabled = true;
                 }

--- a/index.js
+++ b/index.js
@@ -100,36 +100,15 @@ class QrBarToggle {
             //qrBar.style.borderTopColor = 'var(--SmartThemeBodyColor)';
             toggleButton.className = 'fa-solid fa-chevron-down interactable';
             toggleButton.title = 'Collapse QR Bar';
-
-            // Enable buttons within QR bar
-            const buttonsInQrBar = qrBar.querySelectorAll('.qr--button, [id^="qr_"], .inline-drawer-toggle');
-            buttonsInQrBar.forEach(button => {
-                button.style.pointerEvents = 'auto';
-                button.style.opacity = '1';
-                if (button.tagName === 'BUTTON' || (button.tagName === 'INPUT' && button.type === 'button')) {
-                    button.disabled = false;
-                }
-                if (button.hasAttribute('aria-disabled')) {
-                    button.setAttribute('aria-disabled', 'false');
-                }
-            });
+            qrBar.style.pointerEvents = 'auto';
+            qrBar.setAttribute('aria-hidden', 'false');
         } else {
             qrBar.className = `${baseClass} sqrbt-toggle_button-collapsed`;
             //qrBar.style.borderTopColor = 'var(--SmartThemeQuoteColor)';
             toggleButton.className = 'fa-solid fa-chevron-up interactable';
             toggleButton.title = 'Expand QR Bar';
-
-            // Disable buttons within QR bar
-            const buttonsInQrBar = qrBar.querySelectorAll('.qr--button, [id^="qr_"], .inline-drawer-toggle');
-            buttonsInQrBar.forEach(button => {
-                button.style.pointerEvents = 'none';
-                if (button.tagName === 'BUTTON' || (button.tagName === 'INPUT' && button.type === 'button')) {
-                    button.disabled = true;
-                }
-                if (button.hasAttribute('aria-disabled')) {
-                    button.setAttribute('aria-disabled', 'true');
-                }
-            });
+            qrBar.style.pointerEvents = 'none';
+            qrBar.setAttribute('aria-hidden', 'true');
         }
     }
 }


### PR DESCRIPTION
For some reason (I don't exactly know why), even when the quick reply bar height is set to 0px, it's still possible to hover over and click the buttons on the bar by accident. This is very rare on desktop, but fat-fingering these buttons is actually very frequent on mobile.

This pull request uses a loop to disable each button element in the quick reply bar when the bar is collapsed by this extension, and then re-enables each element when the bar is expanded by this extension.

This effectively removes the possibility of fat-fingering a hidden button.